### PR TITLE
Handle folders with a "." in the path

### DIFF
--- a/lib/starting_blocks/watcher.rb
+++ b/lib/starting_blocks/watcher.rb
@@ -17,7 +17,7 @@ module StartingBlocks
     def self.filter_files_by_file_clues files, clues
       files.select do |file|
         file_without_path = file.split('/')[-1]
-        matches = clues.select { |c| the_clue_and_the_file_match c, file }
+        matches = clues.select { |c| the_clue_and_the_file_match c, file_without_path }
         matches.count > 0
       end
     end

--- a/spec/starting_blocks/watcher_spec.rb
+++ b/spec/starting_blocks/watcher_spec.rb
@@ -52,6 +52,18 @@ describe StartingBlocks::Watcher do
       [
         ['ttest_two_spec_something_else.txt', 'test_three.txt'], ['_spec', 'test_'], ['test_three.txt'],
       ],
+      [
+        ['foo/two_spec.txt', 'foo/three_test.txt'], ['_spec', '_test'], ['foo/two_spec.txt', 'foo/three_test.txt'],
+      ],
+      [
+        ['foo.git/two_spec.txt', 'foo.git/three_test.txt'], ['_spec', '_test'], ['foo.git/two_spec.txt', 'foo.git/three_test.txt'],
+      ],
+      [
+        ['foo/bar/two_spec.txt', 'foo/bar/three_test.txt'], ['_spec', '_test'], ['foo/bar/two_spec.txt', 'foo/bar/three_test.txt'],
+      ],
+      [
+        ['foo/bar.git/two_spec.txt', 'foo/bar.git/three_test.txt'], ['_spec', '_test'], ['foo/bar.git/two_spec.txt', 'foo/bar.git/three_test.txt'],
+      ],
     ].map { |x| Struct.new(:files, :clues, :expected).new(*x) }.each do |example|
 
       describe "multiple examples" do


### PR DESCRIPTION
This will handle folders with a "." in the path, such as
project_name.git. The file_without_path was already being set, now
we're passing it in to the the_clue_and_the_file_match method.

These changes address open issue https://github.com/darrencauthon/starting_blocks/issues/28