### PR TITLE
Optional block for bash rb

### DIFF
--- a/lib/starting_blocks/bash.rb
+++ b/lib/starting_blocks/bash.rb
@@ -1,8 +1,8 @@
 module StartingBlocks
   module Bash
-    def self.run command
+    def self.run command, block = Proc.new { |command_to_run| `#{command_to_run}` }
       StartingBlocks::Verbose.say "Running: #{command}"
-      text      = `#{command}`
+      text      = block.call command
       result    = $?
       {
         text:      text,

--- a/lib/starting_blocks/default.rb
+++ b/lib/starting_blocks/default.rb
@@ -22,7 +22,7 @@ module StartingBlocks
 
                       statement_to_execute = ARGV[ARGV.index('execute') + 1]
                       StartingBlocks::Publisher.publish_files_to_run [statement_to_execute]
-                      result = StartingBlocks::Bash.run(statement_to_execute)
+                      result = StartingBlocks::Bash.run(statement_to_execute, block = Proc.new {|x| system( x) })
                       StartingBlocks::Publisher.publish_results( { color: (result[:success] ? :green : :red),
                                                                    tests: 1,
                                                                    assertions: 1,


### PR DESCRIPTION
This allows for callers of the run method to pass a block for running a
command if they want. This is useful in the case of the rspec plugin as
well as the execute command because it allows color to be output in the
results of running the command.
